### PR TITLE
feat: Added FRONTEND_URL environment variable for configurable frontend URLs

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,6 +1,10 @@
 DATABASE_PROVIDER=hybrid
 VECTOR_PROVIDER=qdrant
 
+FRONTEND_URL=http://localhost:3000/
+
+
+
 # Supabase settings for non-vector storage (metadata, user info, etc.)
 SUPABASE_URL=[REDACTED]
 SUPABASE_ANON_KEY=[REDACTED]

--- a/backend/api/v1/routes/auth.py
+++ b/backend/api/v1/routes/auth.py
@@ -521,6 +521,12 @@ async def reset_user_settings(user: User = Depends(get_current_user)):
 
 def _get_frontend_url() -> str:
     """Get frontend URL based on environment."""
+    frontend_url = os.getenv('FRONTEND_URL')
+    if frontend_url:
+        # Remove trailing slash if present
+        return frontend_url.rstrip('/')
+    
+    # Fallback based on environment
     if os.getenv('NODE_ENV') == 'production':
         return 'https://your-frontend-domain.com'
     return 'http://localhost:3002'

--- a/backend/utils/auth_utils.py
+++ b/backend/utils/auth_utils.py
@@ -107,9 +107,19 @@ class GitHubOAuth:
         origins = os.getenv('ALLOWED_ORIGINS', '').split(',')
         origins = [origin.strip() for origin in origins if origin.strip()]
         
+        # Add FRONTEND_URL to allowed origins if set
+        frontend_url = os.getenv('FRONTEND_URL')
+        if frontend_url:
+            frontend_url = frontend_url.rstrip('/')
+            if frontend_url not in origins:
+                origins.append(frontend_url)
+        
         # Add default development origins if not in production
         if os.getenv('NODE_ENV') != 'production':
-            origins.extend(['http://localhost:3000', 'http://127.0.0.1:3000','http://localhost:3002', 'http://127.0.0.1:3002'])
+            default_origins = ['http://localhost:3000', 'http://127.0.0.1:3000', 'http://localhost:3002', 'http://127.0.0.1:3002']
+            for origin in default_origins:
+                if origin not in origins:
+                    origins.append(origin)
         
         return origins
     


### PR DESCRIPTION
## Description
Replace hardcoded frontend URLs with configurable `FRONTEND_URL` environment variable.

## Changes Made
- Add `FRONTEND_URL` to `.env.example`
- Update auth routes to use env var with fallbacks
- Include `FRONTEND_URL` in OAuth allowed origins

## Benefits
- Dynamic frontend URL configuration
- Better deployment flexibility
- Maintains backward compatibility

Fixes #57